### PR TITLE
Add option to deploy udp-only service

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -21,7 +21,7 @@ spec:
       protocol: TCP
       name: statsd-tcp
     {{- end }}
-    {{- if and (empty .Values.statsd.udpPort) (not (empty .Values.service.enable_separate_udp_service)) }}
+    {{- if and (not (empty .Values.statsd.udpPort)) (not .Values.service.enable_separate_udp_service) }}
     - port: {{ .Values.statsd.udpPort }}
       targetPort: statsd-udp
       protocol: UDP

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -21,7 +21,7 @@ spec:
       protocol: TCP
       name: statsd-tcp
     {{- end }}
-    {{- if and (not (empty .Values.statsd.udpPort)) (not .Values.service.enable_separate_udp_service) }}
+    {{- if and (not (empty .Values.statsd.udpPort)) (not .Values.service.enableSeparateUdpService) }}
     - port: {{ .Values.statsd.udpPort }}
       targetPort: statsd-udp
       protocol: UDP
@@ -29,7 +29,7 @@ spec:
     {{- end }}
   selector:
     {{- include "prometheus-statsd-exporter.selectorLabels" . | nindent 4 }}
-{{- if .Values.service.enable_separate_udp_service }}
+{{- if .Values.service.enableSeparateUdpService }}
 ---
 apiVersion: v1
 kind: Service

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -21,7 +21,7 @@ spec:
       protocol: TCP
       name: statsd-tcp
     {{- end }}
-    {{- if .Values.statsd.udpPort }}
+    {{- if and (empty .Values.statsd.udpPort) (not (empty .Values.service.enable_separate_udp_service)) }}
     - port: {{ .Values.statsd.udpPort }}
       targetPort: statsd-udp
       protocol: UDP
@@ -29,3 +29,25 @@ spec:
     {{- end }}
   selector:
     {{- include "prometheus-statsd-exporter.selectorLabels" . | nindent 4 }}
+{{- if .Values.service.enable_separate_udp_service }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prometheus-statsd-exporter.fullname" . }}-udp
+  labels:
+    {{- include "prometheus-statsd-exporter.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.statsd.udpPort }}
+      targetPort: statsd-udp
+      protocol: UDP
+      name: statsd-udp
+  selector:
+    {{- include "prometheus-statsd-exporter.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -32,7 +32,7 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
-  enable_separate_udp_service: false
+  enableSeparateUdpService: false
   type: ClusterIP
   annotations: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -32,6 +32,7 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  enable_separate_udp_service: false
   type: ClusterIP
   annotations: {}
 


### PR DESCRIPTION
On some cloud providers, namely AWS, it isn't currently possible to have a load-balancer handling both TCP and UDP traffic, although this will arrive in the future.

This merge request adds support for deploying a second service that will handle UDP traffic independently.

@jason2506 could you review this please ?